### PR TITLE
打包时自定义包名

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,14 +21,14 @@ function zipFiles(files, filename, source, destination, info, verbose) {
 
 function pack({ source, destination, info, verbose, name, includes }) {
     source = source || './build';
-    name = name ? '.' + name : '';
+    name = name ? name : `${sanitize(process.env.npm_package_name)}_${sanitize(process.env.npm_package_version)}`;
     return packlist({
         path: source,
         bundled: includes.split(',')
     }).then(files => {
         return zipFiles(
             files,
-            `${sanitize(process.env.npm_package_name)}_${sanitize(process.env.npm_package_version)}${name}.zip`,
+            `${name}.zip`,
             source,
             destination,
             info,


### PR DESCRIPTION
use before:
```
input: zip --name=demo
output: 'project_1.0.0_demo.zip'
```
I feel that this usage is not very common sense，so I made minor changes

use after:
```
input: zip --name=demo
output: 'demo.zip'
```
Note: English is not my first language, so if it's semantically offensive please ignore it