### PR TITLE
Add name_only option to tighten file-naming control

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,4 +27,6 @@ npm run zip
 
 `--name=demo` **default is: ''** extra name in package.zip
 
+`--name_only=true` **default is: false** when providing a name, omit package information from filename, does nothing without a name
+
 `--info=true` **default is: false** for show logs

--- a/bin/npm-build-zip.js
+++ b/bin/npm-build-zip.js
@@ -27,6 +27,10 @@ const argv = require('yargs')
         alias: 'n',
         default: false
     })
+    .option('name_only', {
+        alias: 'no',
+        default: false
+    })
     .option('verbose', {
         alias: 'v',
         default: false
@@ -38,8 +42,9 @@ const info = argv.info;
 const verbose = argv.verbose;
 const name = argv.name;
 const includes = argv.includes;
+const name_only = argv.name_only;
 
-pack({ source, destination, info, verbose, name, includes })
+pack({ source, destination, info, verbose, name, includes, name_only })
     .then(() => process.exit(0))
     .catch(error => {
         console.error(error);

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const archiver = require('archiver-promise');
 const packlist = require('npm-packlist');
 const path = require('path');
 const sanitize = require('sanitize-filename');
+const packagejson = require(path.join(process.cwd(), "/package.json"));
 
 function zipFiles(files, filename, source, destination, info, verbose) {
     const target = path.join(destination, filename);
@@ -28,7 +29,7 @@ function pack({ source, destination, info, verbose, name, includes }) {
     }).then(files => {
         return zipFiles(
             files,
-            `${sanitize(process.env.npm_package_name)}_${sanitize(process.env.npm_package_version)}${name}.zip`,
+            `${sanitize(packagejson.name)}_${sanitize(packagejson.version)}${name}.zip`,
             source,
             destination,
             info,

--- a/index.js
+++ b/index.js
@@ -20,16 +20,21 @@ function zipFiles(files, filename, source, destination, info, verbose) {
     return archive.finalize();
 }
 
-function pack({ source, destination, info, verbose, name, includes }) {
+function pack({ source, destination, info, verbose, name, includes, name_only }) {
     source = source || './build';
-    name = name ? '.' + name : '';
+    if (name && name_only) {
+        name = `${name}.zip`;
+    } else {
+        name = name ? '.' + name : '';
+        name = `${sanitize(packagejson.name)}_${sanitize(packagejson.version)}${name}.zip`;
+    }
     return packlist({
         path: source,
         bundled: includes.split(',')
     }).then(files => {
         return zipFiles(
             files,
-            `${sanitize(packagejson.name)}_${sanitize(packagejson.version)}${name}.zip`,
+            name,
             source,
             destination,
             info,


### PR DESCRIPTION
This PR adds the --name_only option, a boolean option which will trigger npm-build-zip to produce "name.zip" when a --name option is provided as opposed to always forcing the package.json's name and version fields into the name. This should achieve the same result as PR #1 while preserving existing functionality.